### PR TITLE
Implement diary count badges

### DIFF
--- a/src/app/diary/annualcalendar.tsx
+++ b/src/app/diary/annualcalendar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import RectangularButton from '../../components/RectangularButton'
 import LogOutButton from '../../components/LogOutButton'
 import CustomButton from '../../components/CustomButton'
+import FetchYearlyCount from '../../components/FetchYearlyCount'
 /*import CircleButton from '../../components/CircleButton'*/
 
 const handlePress = (year: string, month: string): void => {
@@ -14,13 +15,32 @@ const handlePress = (year: string, month: string): void => {
 const annualCalendar = (): JSX.Element => {
   const currentYear = String(new Date().getFullYear())
   const[year, setYear] = useState(currentYear)
+  const [yearlyCount, setYearlyCount] = useState(0)
   const navigation = useNavigation()
+  const daysInYear = new Date(Number(year), 12, 0).getDate()
 
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => { return <LogOutButton /> }
     })
   }, [])
+
+  useEffect(() => {
+    const fetchCount = async () => {
+      const count = await FetchYearlyCount(year)
+      setYearlyCount(count)
+    }
+    fetchCount()
+  }, [year])
+
+  const getCountContainerStyle = () => {
+    if (yearlyCount >= daysInYear) return [styles.countContainer, styles.yearComplete]
+    if (yearlyCount >= 300) return [styles.countContainer, styles.year300]
+    if (yearlyCount >= daysInYear / 2) return [styles.countContainer, styles.yearHalf]
+    if (yearlyCount >= 60) return [styles.countContainer, styles.year60]
+    if (yearlyCount >= 30) return [styles.countContainer, styles.year30]
+    return styles.countContainer
+  }
 
   const changeYear = (offset: number): void => {
     setYear((prevYear) => String(Number(prevYear) + offset))
@@ -35,6 +55,12 @@ const annualCalendar = (): JSX.Element => {
         <Text style={styles.yearText}>{year}</Text>
         <CustomButton title=">" onPress={() => changeYear(1)} backgroundColor='#ffffff' color='#8F8F8F'/>
 
+      </View>
+      <View style={getCountContainerStyle()}>
+        <Text style={styles.countText}>年間日記数: {yearlyCount}</Text>
+        {yearlyCount >= daysInYear && (
+          <Text style={styles.completeText}>コンプリート!</Text>
+        )}
       </View>
       <View style={styles.monthButtons}>
         <View style={styles.JanuaryButton}>
@@ -178,11 +204,58 @@ const styles = StyleSheet.create({
   left: 16,
   top: 448
  },
- DecemberButton: {
-  position: 'absolute',
-  left: 192,
-  top: 448
- }
+  DecemberButton: {
+    position: 'absolute',
+    left: 192,
+    top: 448
+  },
+  countContainer: {
+    alignItems: 'center',
+    marginBottom: 8
+  },
+  year30: {
+    backgroundColor: '#E8F5E9',
+    borderWidth: 2,
+    borderColor: '#66BB6A',
+    borderRadius: 8,
+    padding: 4
+  },
+  year60: {
+    backgroundColor: '#E1F5FE',
+    borderWidth: 2,
+    borderColor: '#42A5F5',
+    borderRadius: 8,
+    padding: 4
+  },
+  yearHalf: {
+    backgroundColor: '#FFFDE7',
+    borderWidth: 2,
+    borderColor: '#FFB300',
+    borderRadius: 8,
+    padding: 4
+  },
+  year300: {
+    backgroundColor: '#FFF3E0',
+    borderWidth: 2,
+    borderColor: '#FF9800',
+    borderRadius: 8,
+    padding: 4
+  },
+  yearComplete: {
+    backgroundColor: '#F3E5F5',
+    borderWidth: 2,
+    borderColor: '#BA68C8',
+    borderRadius: 8,
+    padding: 4
+  },
+  countText: {
+    fontSize: 16,
+    fontWeight: 'bold'
+  },
+  completeText: {
+    fontSize: 14,
+    color: '#BA68C8'
+  }
 })
 
 export default annualCalendar

--- a/src/app/diary/calendar.tsx
+++ b/src/app/diary/calendar.tsx
@@ -58,6 +58,7 @@ const monthlyCalendar = ():JSX.Element => {
   const year = String(searchParams.get('year'))
   const yearMonth: string = year + '-' + month
   const [monthlyData, setMonthlyData] = useState<Record<string, { hasDiary: boolean; hasPhoto: boolean }>>({})
+  const [diaryCount, setDiaryCount] = useState(0)
   const [currentMonth, setCurrentMonth] = useState(month || new Date().getMonth() + 1)
   const [currentYear, setCurrentYear] = useState(year || new Date().getFullYear())
   const [currentYearMonth, setCurrentYearMonth] = useState(yearMonth)
@@ -107,12 +108,22 @@ const monthlyCalendar = ():JSX.Element => {
     }
   }
 
+  const daysInMonth = new Date(Number(currentYear), Number(currentMonth), 0).getDate()
+  const getCountContainerStyle = () => {
+    if (diaryCount >= daysInMonth) return [styles.countContainer, styles.countComplete]
+    if (diaryCount >= daysInMonth / 2) return [styles.countContainer, styles.countHalf]
+    if (diaryCount >= 5) return [styles.countContainer, styles.countFive]
+    return styles.countContainer
+  }
+
   useEffect(() => {
     if (auth.currentUser === null) { return }
     const userUid = auth.currentUser.uid
     const fetchData = async () => {
       const data = await FetchMonthlyData(currentYearMonth)
       setMonthlyData(data)
+      const count = Object.values(data).filter((d) => d.hasDiary).length
+      setDiaryCount(count)
       console.log(`対象月: ${currentYearMonth}`)
     }
     const fetchImageData = async () => {
@@ -216,6 +227,13 @@ const monthlyCalendar = ():JSX.Element => {
         </Text>
       </View>
 
+      <View style={getCountContainerStyle()}>
+        <Text style={styles.countText}>日記数: {diaryCount}</Text>
+        {diaryCount >= daysInMonth && (
+          <Text style={styles.completeText}>コンプリート!</Text>
+        )}
+      </View>
+
       <SafeAreaView style={styles.calendarContainer}>
         <View style={styles.centeredCalendar}>
           <Calendar
@@ -290,6 +308,36 @@ const styles = StyleSheet.create({
   mCalendar: {
     width: 368,
     height: 320
+  },
+  countContainer: {
+    alignItems: 'center',
+    marginTop: 4,
+    marginBottom: 8,
+    padding: 4,
+    borderRadius: 8
+  },
+  countFive: {
+    backgroundColor: '#E8F5E9',
+    borderWidth: 2,
+    borderColor: '#66BB6A'
+  },
+  countHalf: {
+    backgroundColor: '#FFFDE7',
+    borderWidth: 2,
+    borderColor: '#FFB300'
+  },
+  countComplete: {
+    backgroundColor: '#FFF3E0',
+    borderWidth: 2,
+    borderColor: '#FFD700'
+  },
+  countText: {
+    fontSize: 16,
+    fontWeight: 'bold'
+  },
+  completeText: {
+    fontSize: 14,
+    color: '#FF8F00'
   }
 })
 

--- a/src/components/FetchYearlyCount.tsx
+++ b/src/components/FetchYearlyCount.tsx
@@ -1,0 +1,31 @@
+import { getFirestore, collection, query, where, getDocs } from "firebase/firestore"
+import { auth } from "../config"
+
+const FetchYearlyCount = async (year: string): Promise<number> => {
+  const userUid = auth.currentUser?.uid
+  if (!userUid) {
+    console.error("User not authenticated")
+    return 0
+  }
+
+  const db = getFirestore()
+  const diaryCollectionRef = collection(db, `users/${userUid}/diary`)
+  const startDate = `${year}-01-01`
+  const endDate = `${year}-12-31`
+
+  try {
+    const q = query(
+      diaryCollectionRef,
+      where("date", ">=", startDate),
+      where("date", "<=", endDate),
+      where("hasDiary", "==", true)
+    )
+    const querySnapshot = await getDocs(q)
+    return querySnapshot.size
+  } catch (error) {
+    console.error("Error fetching yearly diary count:", error)
+    return 0
+  }
+}
+
+export default FetchYearlyCount


### PR DESCRIPTION
## Summary
- add a utility to fetch yearly diary count
- show monthly diary count in the calendar view with color variations
- show yearly diary count with progressive decorations in the annual calendar

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844df186ce0832aa273123ecf393981